### PR TITLE
 Do not populate db_runtime metrics and drop buckets above 60s

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ You always can add support for your app server to [lib/yabeda/rails/railtie.rb](
 
  - Total web requests received: `rails_requests_total`
  - Web request duration: `rails_request_duration` (in seconds)
- - DB request duration: `rails_db_runtime` (in seconds)
 
 
 ## Hooks

--- a/lib/yabeda/rails.rb
+++ b/lib/yabeda/rails.rb
@@ -12,7 +12,7 @@ module Yabeda
   module Rails
     LONG_RUNNING_REQUEST_BUCKETS = [
       0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, # standard
-      30, 60, 120, 300, 600, # Sometimes requests may be really long-running
+      30, 60, # We timeout requests at 100s. Requests taking more than 60s will end up in the Infinity bucket
     ].freeze
 
     class << self

--- a/lib/yabeda/rails.rb
+++ b/lib/yabeda/rails.rb
@@ -40,10 +40,6 @@ module Yabeda
                                        buckets: LONG_RUNNING_REQUEST_BUCKETS,
                                        comment: "A histogram of the response latency."
 
-          histogram :db_runtime, unit: :seconds, buckets: LONG_RUNNING_REQUEST_BUCKETS,
-                                 comment: "A histogram of the activerecord execution time.",
-                                 tags: %i[controller action status format method]
-
           if config.apdex_target
             gauge :apdex_target, unit: :seconds,
                                  comment: "Tolerable time for Apdex (T value: maximum duration of satisfactory request)"
@@ -55,7 +51,6 @@ module Yabeda
 
             rails_requests_total.increment(event.labels)
             rails_request_duration.measure(event.labels, event.duration)
-            rails_db_runtime.measure(event.labels, event.db_runtime)
 
             Yabeda::Rails.controller_handlers.each do |handler|
               handler.call(event, event.labels)

--- a/lib/yabeda/rails/event.rb
+++ b/lib/yabeda/rails/event.rb
@@ -21,10 +21,6 @@ module Yabeda
         ms2s super
       end
 
-      def db_runtime
-        ms2s payload[:db_runtime]
-      end
-
       private
 
       def controller


### PR DESCRIPTION
We do not need it as we rely on our tracing to troubleshoot slow DB calls which is likely to be more useful than a single metric aggregating all db calls together per request.

rails_db_runtime metrics represent almost 50% of the metrics exporter by our rails pods so I reckon it's worth dropping it.


Also drop 3 buckets from the LONG_RUNNING_REQUESTS_BUCKETS list. Because we timeout requests at 100s, we dont need buckets 120,300 and 600